### PR TITLE
Add scripts for backfill and fix configure script

### DIFF
--- a/finance_scraping/scripts/backfill_load.sh
+++ b/finance_scraping/scripts/backfill_load.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# this script backfills the transform step (parse HTML pages) from the finance-scraping
+# ETL pipeline
+# dates are inclusive and have to be in format YYYY-MM-DD
+# use: bash backfill_transform.sh <start date> <end date>
+
+START=$1
+END=$(date -I -d "$2 + 1 day")
+
+while [[ $START != $END ]]; do
+    if [[ $(date +%u -d $START) -le 5 ]]; then
+	echo "loading data for $START"
+	finance-scraper -l -d $START
+    fi
+    START=$(date -I -d "$START + 1 day")
+done
+
+echo "loading done"

--- a/finance_scraping/scripts/backfill_transform.sh
+++ b/finance_scraping/scripts/backfill_transform.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+# this script backfills the transform step (parse HTML pages) from the finance-scraping
+# ETL pipeline
+# dates are inclusive and have to be in format YYYY-MM-DD
+# use: bash backfill_transform.sh <start date> <end date>
+
+START=$1
+END=$(date -I -d "$2 + 1 day")
+
+while [[ $START != $END ]]; do
+    if [[ $(date +%u -d $START) -le 5 ]]; then
+	echo "parsing web pages for $START"
+	finance-scraper -t -d $START
+    fi
+    START=$(date -I -d "$START + 1 day")
+done
+
+echo "parsing done"

--- a/finance_scraping/scripts/configure.sh
+++ b/finance_scraping/scripts/configure.sh
@@ -5,8 +5,8 @@
 ENV_FILE=~/.bashrc
 
 declare -a PARAMS=(s3_bucket aws_profile urls_s3_key user_agent \
-    max_retries backoff_factor retry_on timeout database table db_user \
-    password host port)
+    max_retries backoff_factor retry_on timeout db_name db_table db_username \
+    db_password host port)
 
 echo "Please enter configuration values: "
 echo

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-__version__ = '0.6.1'
+__version__ = '0.6.3'
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
We add two BASH scripts for backfilling transform and load steps
between two dates. We also update the name of the environment variables
in the BASH configuration because they were not consistent with what is
expected during setup.