### PR TITLE
pass dag run date to tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 dist
 finance_scraping.egg-info/*
 *backend.hcl
+finance_scraping_vars

--- a/finance_scraping/finance_scraping_dag.py
+++ b/finance_scraping/finance_scraping_dag.py
@@ -33,12 +33,14 @@ extract_task = PythonOperator(
 transform_task = PythonOperator(
     task_id='transform',
     python_callable=transform,
+    op_kwargs={"date": "{{ ds }}"},
     dag=dag
 )
 
 load_task = PythonOperator(
     task_id='load',
     python_callable=load,
+    op_kwargs={"date": "{{ ds }}"},
     dag=dag
 )
 

--- a/finance_scraping/loading.py
+++ b/finance_scraping/loading.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import psycopg2
 

--- a/finance_scraping/loading.py
+++ b/finance_scraping/loading.py
@@ -129,7 +129,6 @@ def check_table_for_loaded_data(
         else:
             msg = f"aborting load in table '{table_name}'"
             logging.info(msg)
-            sys.exit()
 
 
 def copy_into(

--- a/finance_scraping/utils.py
+++ b/finance_scraping/utils.py
@@ -40,7 +40,6 @@ def parse_cli():
         action='store_true',
         help='configure the scraper for local use, requires user input')
 
-
     parser.add_argument(
         '-c',
         '--configure',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -153,7 +153,6 @@ class TestLoading(TestCase):
             [(statement, ('mytable', '2019-08-31'))], connection_mock
         )
 
-    @patch("finance_scraping.loading.sys.exit")
     @patch("finance_scraping.loading.logging.info")
     @patch("finance_scraping.loading.data_already_loaded")
     @patch("finance_scraping.loading.get_connection")
@@ -162,7 +161,6 @@ class TestLoading(TestCase):
         connection_mock,
         loaded_mock,
         logging_mock,
-        sys_exit_mock
     ):
         loaded_mock.return_value = True
         check_table_for_loaded_data(
@@ -175,7 +173,6 @@ class TestLoading(TestCase):
             call('data was already loaded on 2019-08-31'),
             call("aborting load in table 'mytable'")
         ])
-        sys_exit_mock.assert_called_once()
 
     @patch("finance_scraping.loading.get_connection")
     def test_copy_into(self, connection_mock):

--- a/tests/test_parsing_html.py
+++ b/tests/test_parsing_html.py
@@ -51,51 +51,51 @@ class TestParsingHTMLBeautifulSoup(TestCase):
 
     def test_get_company_name(self):
         name = get_company_name(self.soup)
-        self.assertEqual(name, 'Dolphin Integration SA')
+        self.assertEqual(name, 'Acteos')
 
     def test_get_company_symbol(self):
         name = get_company_symbol(self.soup)
-        self.assertEqual(name, 'ALDOL')
+        self.assertEqual(name, 'EOS')
 
     def test_get_last_quote(self):
         quote = get_last_quote(self.soup)
-        self.assertEqual(quote, 3.66)
+        self.assertEqual(quote, 0.9)
 
     def test_get_date_time(self):
         time, date = get_date_time(self.soup)
-        self.assertEqual(date, '2018-08-16')
-        self.assertEqual(time, '07:15:07')
+        self.assertEqual(date, '2019-08-30')
+        self.assertEqual(time, '16:38:37')
 
     def test_get_daily_change(self):
         absolute, relative = get_daily_change(self.soup)
-        self.assertEqual(absolute, 0.20)
-        self.assertAlmostEqual(relative, 0.0578)
+        self.assertEqual(absolute, -0.01)
+        self.assertAlmostEqual(relative, -0.0153)
 
     def test_get_bid_offer(self):
         bid, offer = get_bid_offer(self.soup)
-        self.assertAlmostEqual(bid, 2.46)
-        self.assertAlmostEqual(offer, 3.66)
+        self.assertAlmostEqual(bid, 0.9)
+        self.assertAlmostEqual(offer, 0.92)
 
     def test_get_low_high(self):
         low, high = get_low_high(self.soup)
-        self.assertAlmostEqual(low, 3.60)
-        self.assertAlmostEqual(high, 3.66)
+        self.assertAlmostEqual(low, 0.9)
+        self.assertAlmostEqual(high, 0.92)
 
     def test_get_daily_volume(self):
         volume = get_daily_volume(self.soup)
-        self.assertAlmostEqual(volume, 1344)
+        self.assertAlmostEqual(volume, 878)
 
     def test_get_capital(self):
         capital = get_capital(self.soup)
-        self.assertTrue(isnan(capital))
+        self.assertFalse(isnan(capital))
 
     def test_get_closing_value(self):
         last_close = get_closing_value(self.soup)
-        self.assertAlmostEqual(last_close, 3.46)
+        self.assertAlmostEqual(last_close, 0.92)
 
     def test_get_PE_ratio(self):
         ratio = get_PE_ratio(self.soup)
-        self.assertAlmostEqual(ratio, 11.44)
+        self.assertAlmostEqual(ratio, -5.97)
 
     def test_get_yield(self):
         y = get_yield(self.soup)


### PR DESCRIPTION
The DAG tasks were not using the DAG run date, so there were DAG failures if the pipeline was running around midnight UTC. This is because timestamps are included in file names and one task would save files on one date but the next task would look for files for the next day.