### PR TITLE
collection date = Airflow date + 1 business day

### DIFF
--- a/finance_scraping/utils.py
+++ b/finance_scraping/utils.py
@@ -1,6 +1,25 @@
 import argparse
-from dateutil import parser
 import os
+
+from datetime import timedelta
+from dateutil import parser
+
+
+def add_business_days(date, n=1):
+    """
+    Add n business days to a date (skip weekends).
+
+    :param datetime.datetime date: starting date
+    :param int n: number of business days to add, optional (defaults 1)
+    :returns: datetime.datetime - date after adding n business days
+    """
+    while n > 0:
+        date += timedelta(days=1)
+        weekday = date.weekday()
+        if weekday >= 5:  # monday is 0
+            continue
+        n -= 1
+    return date
 
 
 def remove_header(text, separator=os.linesep):
@@ -18,13 +37,16 @@ def remove_header(text, separator=os.linesep):
 
 def format_date(date):
     """
-    Format a string representing a date into '%Y/%m/%d'.
+    Format a string representing a date into '%Y/%m/%d' and add 1 business
+    days (Airflow DAG run date is the date at the start of the schedule
+    interval, which is 1 day for this DAG).
 
     :param str date: date to format
     :return str: formatted date
     """
-    date = parser.parse(date)
-    return date.strftime('%Y/%m/%d')
+    parsed = parser.parse(date)
+    current_date = add_business_days(parsed)
+    return current_date.strftime('%Y/%m/%d')
 
 
 def parse_cli():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,17 +14,32 @@ class TestUtils(TestCase):
         no_header = remove_header(text, separator='\n')
         self.assertEqual(no_header, expected)
 
-    def test_format_date(self):
-        expected = '2019/08/31'
+    def test_format_date_monday(self):
+        expected = '2020/09/22'
 
-        input_date = '31-08-2019'
+        input_date = '21-09-2020'
         date = format_date(input_date)
         self.assertEqual(expected, date)
 
-        input_date = '31 August 2019'
+        input_date = '21 September 2020'
         date = format_date(input_date)
         self.assertEqual(expected, date)
 
-        input_date = 'August, 31st 2019'
+        input_date = 'September, 21st 2020'
+        date = format_date(input_date)
+        self.assertEqual(expected, date)
+
+    def test_format_date_friday(self):
+        expected = '2020/09/21'
+
+        input_date = '18-09-2020'
+        date = format_date(input_date)
+        self.assertEqual(expected, date)
+
+        input_date = '18 September 2020'
+        date = format_date(input_date)
+        self.assertEqual(expected, date)
+
+        input_date = 'September, 18th 2020'
         date = format_date(input_date)
         self.assertEqual(expected, date)


### PR DESCRIPTION
Airflow's DAG run date is the date at the start of the schedule
interval, so this is one day before the actual date at which the job
runs for a daily DAG. We store the 'collection date' in the database,
which was set with the DAG run date, so it was wrong. Now we add one
business day to the DAG run date to obtain the collection date.